### PR TITLE
Process individual items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Spring Boot Event Processor
 
-This project provides a basic Spring Boot application that consumes Kafka events
-and propagates new ones. When a purchase event is consumed from `example-topic`,
-the application emits a copy of that event to `assembly-line-topic` and
-`inventory-topic`.
+This project provides a basic Spring Boot application that consumes purchase
+events from the `new_order` topic and breaks them into production orders. For
+each item in a received purchase, a new event is emitted to
+`assembly-line-topic` so that the production line can start processing it.
 
 ## Build
 


### PR DESCRIPTION
## Summary
- parse order events and emit one production event per item
- remove inventory topic
- document new workflow in README

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687c110c884c8323ae6c8492a93c194a