### PR TITLE
Refactor consumer logic into SOLID services

### DIFF
--- a/src/main/java/com/example/kafkaconsumer/KafkaConsumerService.java
+++ b/src/main/java/com/example/kafkaconsumer/KafkaConsumerService.java
@@ -2,72 +2,27 @@ package com.example.kafkaconsumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.core.KafkaTemplate;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.example.kafkaconsumer.model.Item;
-import com.example.kafkaconsumer.model.Purchase;
-import com.example.kafkaconsumer.repository.PurchaseRepository;
-import java.util.ArrayList;
-import java.util.List;
+import com.example.kafkaconsumer.service.PurchaseService;
 import org.springframework.stereotype.Service;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.retry.annotation.Recover;
-import java.util.concurrent.ExecutionException;
 
 @Service
 public class KafkaConsumerService {
     private static final Logger logger = LoggerFactory.getLogger(KafkaConsumerService.class);
 
-    private static final String ASSEMBLY_TOPIC = "assembly-line-topic";
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
-    private final KafkaTemplate<String, String> kafkaTemplate;
-    private final PurchaseRepository purchaseRepository;
-
-    @Autowired
-    public KafkaConsumerService(KafkaTemplate<String, String> kafkaTemplate,
-                                PurchaseRepository purchaseRepository) {
-        this.kafkaTemplate = kafkaTemplate;
-        this.purchaseRepository = purchaseRepository;
+    private final PurchaseService purchaseService;
+    public KafkaConsumerService(PurchaseService purchaseService) {
+        this.purchaseService = purchaseService;
     }
 
     @KafkaListener(topics = "new_order", groupId = "example-group")
     @Retryable(value = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 1000))
-    public void listen(String message) throws ExecutionException, InterruptedException {
+    public void listen(String message) throws Exception {
         logger.info("Received message: {}", message);
-        JsonNode root = MAPPER.readTree(message);
-        String timestamp = root.path("eventTimestamp").asText();
-        String purchaseId = root.path("payload").path("purchaseId").asText();
-        ArrayNode items = (ArrayNode) root.path("payload").path("items");
-
-        List<Item> itemList = new ArrayList<>();
-        for (JsonNode item : items) {
-            ObjectNode out = MAPPER.createObjectNode();
-            out.put("eventType", "PRODUCTION_ITEM");
-            out.put("eventTimestamp", timestamp);
-            ObjectNode payload = out.putObject("payload");
-            payload.put("purchaseId", purchaseId);
-            payload.put("productId", item.path("productId").asText());
-            payload.put("quantity", item.path("quantity").asInt());
-            kafkaTemplate.send(ASSEMBLY_TOPIC, MAPPER.writeValueAsString(out)).get();
-
-            Item orderItem = new Item();
-            orderItem.setProductId(item.path("productId").asText());
-            orderItem.setQuantity(item.path("quantity").asInt());
-            itemList.add(orderItem);
-        }
-        Purchase purchase = new Purchase();
-        purchase.setPurchaseId(purchaseId);
-        purchase.setEventTimestamp(timestamp);
-        purchase.setItems(itemList);
-        purchaseRepository.save(purchase);
-        logger.info("Emitted {} production events to {}", items.size(), ASSEMBLY_TOPIC);
+        purchaseService.process(message);
     }
 
     @Recover

--- a/src/main/java/com/example/kafkaconsumer/service/EventPublisher.java
+++ b/src/main/java/com/example/kafkaconsumer/service/EventPublisher.java
@@ -1,0 +1,5 @@
+package com.example.kafkaconsumer.service;
+
+public interface EventPublisher {
+    void publish(String topic, String message) throws Exception;
+}

--- a/src/main/java/com/example/kafkaconsumer/service/KafkaEventPublisher.java
+++ b/src/main/java/com/example/kafkaconsumer/service/KafkaEventPublisher.java
@@ -1,0 +1,20 @@
+package com.example.kafkaconsumer.service;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import java.util.concurrent.ExecutionException;
+
+@Component
+public class KafkaEventPublisher implements EventPublisher {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public KafkaEventPublisher(KafkaTemplate<String, String> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    @Override
+    public void publish(String topic, String message) throws ExecutionException, InterruptedException {
+        kafkaTemplate.send(topic, message).get();
+    }
+}


### PR DESCRIPTION
## Summary
- extract `EventPublisher` interface and implementation `KafkaEventPublisher`
- add `PurchaseService` for purchase processing
- simplify `KafkaConsumerService` to delegate work to `PurchaseService`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687c1547ca2083239d0efa3c417065f0