### PR TITLE
Add unit tests and improve exception handling

### DIFF
--- a/src/main/java/com/example/kafkaconsumer/KafkaConsumerService.java
+++ b/src/main/java/com/example/kafkaconsumer/KafkaConsumerService.java
@@ -20,7 +20,7 @@ public class KafkaConsumerService {
 
     @KafkaListener(topics = "new_order", groupId = "example-group")
     @Retryable(value = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 1000))
-    public void listen(String message) throws Exception {
+    public void listen(String message) {
         logger.info("Received message: {}", message);
         purchaseService.process(message);
     }

--- a/src/main/java/com/example/kafkaconsumer/service/EventPublishException.java
+++ b/src/main/java/com/example/kafkaconsumer/service/EventPublishException.java
@@ -1,0 +1,7 @@
+package com.example.kafkaconsumer.service;
+
+public class EventPublishException extends RuntimeException {
+    public EventPublishException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/com/example/kafkaconsumer/KafkaConsumerServiceTest.java
+++ b/src/test/java/com/example/kafkaconsumer/KafkaConsumerServiceTest.java
@@ -1,0 +1,33 @@
+package com.example.kafkaconsumer;
+
+import com.example.kafkaconsumer.service.PurchaseService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaConsumerServiceTest {
+
+    @Mock
+    PurchaseService purchaseService;
+
+    @InjectMocks
+    KafkaConsumerService kafkaConsumerService;
+
+    @Test
+    void listenDelegatesToPurchaseService() {
+        kafkaConsumerService.listen("msg");
+        verify(purchaseService).process("msg");
+    }
+
+    @Test
+    void exceptionFromPurchaseServicePropagates() {
+        doThrow(new RuntimeException("fail")).when(purchaseService).process("x");
+        assertThrows(RuntimeException.class, () -> kafkaConsumerService.listen("x"));
+    }
+}

--- a/src/test/java/com/example/kafkaconsumer/service/PurchaseServiceTest.java
+++ b/src/test/java/com/example/kafkaconsumer/service/PurchaseServiceTest.java
@@ -1,0 +1,67 @@
+package com.example.kafkaconsumer.service;
+
+import com.example.kafkaconsumer.model.Purchase;
+import com.example.kafkaconsumer.repository.PurchaseRepository;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongCounterBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PurchaseServiceTest {
+
+    @Mock
+    EventPublisher eventPublisher;
+    @Mock
+    PurchaseRepository purchaseRepository;
+    @Mock
+    Meter meter;
+    @Mock
+    LongCounterBuilder longCounterBuilder;
+    @Mock
+    LongCounter longCounter;
+
+    PurchaseService purchaseService;
+
+    @BeforeEach
+    void setUp() {
+        when(meter.counterBuilder(anyString())).thenReturn(longCounterBuilder);
+        when(longCounterBuilder.setDescription(anyString())).thenReturn(longCounterBuilder);
+        when(longCounterBuilder.build()).thenReturn(longCounter);
+        purchaseService = new PurchaseService(eventPublisher, purchaseRepository, meter);
+    }
+
+    @Test
+    void processPublishesEventsAndSavesPurchase() throws Exception {
+        String json = "{\"eventTimestamp\":\"2024-01-01\",\"payload\":{\"purchaseId\":\"p1\",\"items\":[{\"productId\":\"A\",\"quantity\":1},{\"productId\":\"B\",\"quantity\":2}]}}";
+
+        purchaseService.process(json);
+
+        verify(eventPublisher, times(2)).publish(eq("assembly-line-topic"), anyString());
+        verify(purchaseRepository).save(any(Purchase.class));
+        verify(longCounter).add(1);
+    }
+
+    @Test
+    void invalidJsonThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> purchaseService.process("not-json"));
+    }
+
+    @Test
+    void publishFailureThrowsEventPublishException() throws Exception {
+        String json = "{\"eventTimestamp\":\"2024-01-01\",\"payload\":{\"purchaseId\":\"p1\",\"items\":[{\"productId\":\"A\",\"quantity\":1}]}}";
+        doThrow(new Exception("fail")).when(eventPublisher).publish(anyString(), anyString());
+
+        assertThrows(EventPublishException.class, () -> purchaseService.process(json));
+    }
+}


### PR DESCRIPTION
## Summary
- handle JSON and publishing errors in `PurchaseService`
- remove checked exception signature from `KafkaConsumerService.listen`
- add `EventPublishException`
- add unit tests for `PurchaseService` and `KafkaConsumerService`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687c181dafd083238e53feb5e5e4d7ee