### PR TITLE
Add unit tests for all components

### DIFF
--- a/src/test/java/com/example/kafkaconsumer/ApplicationTest.java
+++ b/src/test/java/com/example/kafkaconsumer/ApplicationTest.java
@@ -1,0 +1,14 @@
+package com.example.kafkaconsumer;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ApplicationTest {
+
+    @Test
+    void applicationIsAnnotated() {
+        assertNotNull(Application.class.getAnnotation(SpringBootApplication.class));
+    }
+}

--- a/src/test/java/com/example/kafkaconsumer/config/TelemetryConfigTest.java
+++ b/src/test/java/com/example/kafkaconsumer/config/TelemetryConfigTest.java
@@ -1,0 +1,21 @@
+package com.example.kafkaconsumer.config;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TelemetryConfigTest {
+
+    @Test
+    void beansAreCreated() {
+        TelemetryConfig config = new TelemetryConfig();
+        OpenTelemetry otel = config.openTelemetry();
+        Meter meter = config.otelMeter(otel);
+        assertNotNull(otel);
+        assertNotNull(meter);
+        ((OpenTelemetrySdk) otel).getSdkMeterProvider().close();
+    }
+}

--- a/src/test/java/com/example/kafkaconsumer/model/ItemTest.java
+++ b/src/test/java/com/example/kafkaconsumer/model/ItemTest.java
@@ -1,0 +1,18 @@
+package com.example.kafkaconsumer.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ItemTest {
+
+    @Test
+    void gettersAndSetters() {
+        Item item = new Item();
+        item.setProductId("P1");
+        item.setQuantity(3);
+
+        assertEquals("P1", item.getProductId());
+        assertEquals(3, item.getQuantity());
+    }
+}

--- a/src/test/java/com/example/kafkaconsumer/model/PurchaseTest.java
+++ b/src/test/java/com/example/kafkaconsumer/model/PurchaseTest.java
@@ -1,0 +1,26 @@
+package com.example.kafkaconsumer.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PurchaseTest {
+
+    @Test
+    void gettersAndSetters() {
+        Purchase purchase = new Purchase();
+        purchase.setPurchaseId("id");
+        purchase.setEventTimestamp("ts");
+        Item item = new Item();
+        item.setProductId("p");
+        item.setQuantity(1);
+        purchase.setItems(List.of(item));
+
+        assertEquals("id", purchase.getPurchaseId());
+        assertEquals("ts", purchase.getEventTimestamp());
+        assertEquals(1, purchase.getItems().size());
+        assertEquals("p", purchase.getItems().get(0).getProductId());
+    }
+}

--- a/src/test/java/com/example/kafkaconsumer/service/EventPublishExceptionTest.java
+++ b/src/test/java/com/example/kafkaconsumer/service/EventPublishExceptionTest.java
@@ -1,0 +1,16 @@
+package com.example.kafkaconsumer.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EventPublishExceptionTest {
+
+    @Test
+    void storesMessageAndCause() {
+        Exception cause = new Exception("cause");
+        EventPublishException ex = new EventPublishException("msg", cause);
+        assertEquals("msg", ex.getMessage());
+        assertEquals(cause, ex.getCause());
+    }
+}

--- a/src/test/java/com/example/kafkaconsumer/service/KafkaEventPublisherTest.java
+++ b/src/test/java/com/example/kafkaconsumer/service/KafkaEventPublisherTest.java
@@ -1,0 +1,31 @@
+package com.example.kafkaconsumer.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.util.concurrent.SettableListenableFuture;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaEventPublisherTest {
+
+    @Mock
+    KafkaTemplate<String, String> kafkaTemplate;
+
+    @Test
+    void publishSendsMessage() throws Exception {
+        SettableListenableFuture<SendResult<String, String>> future = spy(new SettableListenableFuture<>());
+        future.set(null);
+        when(kafkaTemplate.send("topic", "msg")).thenReturn(future);
+        KafkaEventPublisher publisher = new KafkaEventPublisher(kafkaTemplate);
+
+        publisher.publish("topic", "msg");
+
+        verify(kafkaTemplate).send("topic", "msg");
+        verify(future).get();
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for KafkaEventPublisher
- cover EventPublishException behaviour
- test basic getters/setters in domain models
- validate telemetry configuration bean creation
- check Application annotation

## Testing
- `mvn test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687c1fe93cbc83239d78146b7b8891f7