### PR TITLE
Atualizar namespaces para com.pworks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.example</groupId>
+    <groupId>com.pworks</groupId>
     <artifactId>springboot-event-processor</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <parent>

--- a/src/main/java/com/pworks/kafkaconsumer/Application.java
+++ b/src/main/java/com/pworks/kafkaconsumer/Application.java
@@ -1,4 +1,4 @@
-package com.example.kafkaconsumer;
+package com.pworks.kafkaconsumer;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/pworks/kafkaconsumer/KafkaConsumerService.java
+++ b/src/main/java/com/pworks/kafkaconsumer/KafkaConsumerService.java
@@ -1,9 +1,9 @@
-package com.example.kafkaconsumer;
+package com.pworks.kafkaconsumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
-import com.example.kafkaconsumer.service.PurchaseService;
+import com.pworks.kafkaconsumer.service.PurchaseService;
 import org.springframework.stereotype.Service;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;

--- a/src/main/java/com/pworks/kafkaconsumer/config/TelemetryConfig.java
+++ b/src/main/java/com/pworks/kafkaconsumer/config/TelemetryConfig.java
@@ -1,4 +1,4 @@
-package com.example.kafkaconsumer.config;
+package com.pworks.kafkaconsumer.config;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.Meter;

--- a/src/main/java/com/pworks/kafkaconsumer/model/Item.java
+++ b/src/main/java/com/pworks/kafkaconsumer/model/Item.java
@@ -1,4 +1,4 @@
-package com.example.kafkaconsumer.model;
+package com.pworks.kafkaconsumer.model;
 
 public class Item {
     private String productId;

--- a/src/main/java/com/pworks/kafkaconsumer/model/Purchase.java
+++ b/src/main/java/com/pworks/kafkaconsumer/model/Purchase.java
@@ -1,4 +1,4 @@
-package com.example.kafkaconsumer.model;
+package com.pworks.kafkaconsumer.model;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;

--- a/src/main/java/com/pworks/kafkaconsumer/repository/PurchaseRepository.java
+++ b/src/main/java/com/pworks/kafkaconsumer/repository/PurchaseRepository.java
@@ -1,7 +1,7 @@
-package com.example.kafkaconsumer.repository;
+package com.pworks.kafkaconsumer.repository;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
-import com.example.kafkaconsumer.model.Purchase;
+import com.pworks.kafkaconsumer.model.Purchase;
 
 public interface PurchaseRepository extends MongoRepository<Purchase, String> {
 }

--- a/src/main/java/com/pworks/kafkaconsumer/service/EventPublishException.java
+++ b/src/main/java/com/pworks/kafkaconsumer/service/EventPublishException.java
@@ -1,4 +1,4 @@
-package com.example.kafkaconsumer.service;
+package com.pworks.kafkaconsumer.service;
 
 public class EventPublishException extends RuntimeException {
     public EventPublishException(String message, Throwable cause) {

--- a/src/main/java/com/pworks/kafkaconsumer/service/EventPublisher.java
+++ b/src/main/java/com/pworks/kafkaconsumer/service/EventPublisher.java
@@ -1,4 +1,4 @@
-package com.example.kafkaconsumer.service;
+package com.pworks.kafkaconsumer.service;
 
 public interface EventPublisher {
     void publish(String topic, String message) throws Exception;

--- a/src/main/java/com/pworks/kafkaconsumer/service/KafkaEventPublisher.java
+++ b/src/main/java/com/pworks/kafkaconsumer/service/KafkaEventPublisher.java
@@ -1,4 +1,4 @@
-package com.example.kafkaconsumer.service;
+package com.pworks.kafkaconsumer.service;
 
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/pworks/kafkaconsumer/service/PurchaseService.java
+++ b/src/main/java/com/pworks/kafkaconsumer/service/PurchaseService.java
@@ -1,8 +1,8 @@
-package com.example.kafkaconsumer.service;
+package com.pworks.kafkaconsumer.service;
 
-import com.example.kafkaconsumer.model.Item;
-import com.example.kafkaconsumer.model.Purchase;
-import com.example.kafkaconsumer.repository.PurchaseRepository;
+import com.pworks.kafkaconsumer.model.Item;
+import com.pworks.kafkaconsumer.model.Purchase;
+import com.pworks.kafkaconsumer.repository.PurchaseRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/com/pworks/kafkaconsumer/KafkaConsumerServiceTest.java
+++ b/src/test/java/com/pworks/kafkaconsumer/KafkaConsumerServiceTest.java
@@ -1,6 +1,6 @@
-package com.example.kafkaconsumer;
+package com.pworks.kafkaconsumer;
 
-import com.example.kafkaconsumer.service.PurchaseService;
+import com.pworks.kafkaconsumer.service.PurchaseService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;

--- a/src/test/java/com/pworks/kafkaconsumer/service/PurchaseServiceTest.java
+++ b/src/test/java/com/pworks/kafkaconsumer/service/PurchaseServiceTest.java
@@ -1,7 +1,7 @@
-package com.example.kafkaconsumer.service;
+package com.pworks.kafkaconsumer.service;
 
-import com.example.kafkaconsumer.model.Purchase;
-import com.example.kafkaconsumer.repository.PurchaseRepository;
+import com.pworks.kafkaconsumer.model.Purchase;
+import com.pworks.kafkaconsumer.repository.PurchaseRepository;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongCounterBuilder;
 import io.opentelemetry.api.metrics.Meter;


### PR DESCRIPTION
## Summary
- rename main and test packages from `com.example` to `com.pworks`
- update Maven `groupId`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687c20ae65bc8323aef9ff61701342cb