### PR TITLE
Switch metrics exporter to OTLP

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This application consumes purchase events from Kafka, stores them in MongoDB and
 emits one production event per item. Metrics are exported through OpenTelemetry
-so Prometheus or Grafana can monitor the processing pipeline.
+using the OTLP protocol so Grafana or other observability tools can monitor the
+processing pipeline.
 
 ## Architecture
 
@@ -14,7 +15,7 @@ graph TD
     C -->|for each item| E[KafkaEventPublisher]
     E --> F[(assembly-line-topic)]
     C --> G[OpenTelemetry]
-    G --> H[(Prometheus)]
+    G --> H[(OTLP Collector)]
 ```
 
 ## Build
@@ -35,9 +36,9 @@ Before the first run initialise MongoDB:
 mongo < scripts/mongo-init.js
 ```
 
-Metrics are available on `http://localhost:9464/metrics`. Connection properties
-for Kafka and MongoDB are defined in
-`src/main/resources/application.properties`.
+Metrics are exported to the OTLP endpoint defined by the `OTEL_EXPORTER_OTLP_ENDPOINT`
+environment variable (defaults to `http://localhost:4317`). Connection properties
+for Kafka and MongoDB are defined in `src/main/resources/application.properties`.
 
 ## Continuous Integration
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-prometheus</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
             <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/com/pworks/kafkaconsumer/config/TelemetryConfig.java
+++ b/src/main/java/com/pworks/kafkaconsumer/config/TelemetryConfig.java
@@ -4,7 +4,10 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
-import io.opentelemetry.exporter.prometheus.PrometheusHttpServer;
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,10 +16,13 @@ public class TelemetryConfig {
 
     @Bean
     public OpenTelemetry openTelemetry() {
+        MetricExporter metricExporter = OtlpGrpcMetricExporter.builder()
+                .setEndpoint(System.getenv().getOrDefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"))
+                .build();
+
         SdkMeterProvider meterProvider = SdkMeterProvider.builder()
-                .registerMetricReader(PrometheusHttpServer.builder()
-                        .setHost("0.0.0.0")
-                        .setPort(9464)
+                .registerMetricReader(PeriodicMetricReader.builder(metricExporter)
+                        .setInterval(Duration.ofSeconds(30))
                         .build())
                 .build();
 


### PR DESCRIPTION
## Summary
- switch Prometheus exporter to OTLP
- update OTLP endpoint logic in `TelemetryConfig`
- document new OTLP configuration in README

## Testing
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-starter-parent due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687c26c124388323b53f5849eed6fc9e